### PR TITLE
Remove outdated include file complexmatrix.h in diago_david.h

### DIFF
--- a/source/module_hsolver/diago_david.h
+++ b/source/module_hsolver/diago_david.h
@@ -11,7 +11,6 @@
 #define DIAGODAVID_H
 
 #include "diagh.h"
-#include "module_base/complexmatrix.h"
 #include "module_base/macros.h"
 #include "module_hamilt_pw/hamilt_pwdft/structure_factor.h"
 #include "module_psi/kernels/device.h"
@@ -19,12 +18,12 @@
 namespace hsolver
 {
 
-template <typename T = std::complex<double>, typename Device = psi::DEVICE_CPU> 
+template <typename T = std::complex<double>, typename Device = psi::DEVICE_CPU>
 class DiagoDavid : public DiagH<T, Device>
 {
   private:
-    // Note GetTypeReal<T>::type will 
-    // return T if T is real type(float, double), 
+    // Note GetTypeReal<T>::type will
+    // return T if T is real type(float, double),
     // otherwise return the real type of T(complex<float>, complex<double>)
     using Real = typename GetTypeReal<T>::type;
   public:


### PR DESCRIPTION

remove outdated include file `complexmatrix.h` in `diago_david.h`

---
### Reminder
- [ ] Have you linked an issue with this pull request?
- [ ] Have you noticed possible changes of behavior below or in the linked issue?
- [ ] Have you explained the changes of codes in core modules of ESolver, HSolver, ElecState, Hamilt, Operator or Psi? (ignore if not applicable)

### Linked Issue
Fix #...

### What's changed?
- Example: My changes might affect the performance of the application under certain conditions, and I have tested the impact on various scenarios...

### Any changes of core modules? (ignore if not applicable)
- Example: I have added a new virtual function in the esolver base class in order to ...
